### PR TITLE
Replace IPNetwork2 with plain code, and simplify unicast IP lookup

### DIFF
--- a/src/Nefarius.Utilities.AspNetCore.csproj
+++ b/src/Nefarius.Utilities.AspNetCore.csproj
@@ -38,9 +38,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IPNetwork2" Version="3.0.667">
-            <Aliases>IPNetwork2</Aliases>
-        </PackageReference>
         <PackageReference Include="MinVer" Version="5.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Util/NetworkUtil.cs
+++ b/src/Util/NetworkUtil.cs
@@ -1,27 +1,62 @@
-﻿extern alias IPNetwork2;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
-using IPNetwork = IPNetwork2::System.Net.IPNetwork2;
+#if !NET8_0_OR_GREATER
+// Tuple substitute, since we only care about the values
+using IPNetwork = (System.Net.IPAddress BaseAddress, int PrefixLength);
+#endif
 
 namespace Nefarius.Utilities.AspNetCore.Util;
 
 internal static class NetworkUtil
 {
-    public static IEnumerable<IPNetwork> GetNetworks(NetworkInterfaceType type)
+    public static IEnumerable<IPNetwork> GetNetworks()
+        => IPGlobalProperties
+            .GetIPGlobalProperties()
+            .GetUnicastAddresses()
+            .Select(GetIPNetwork);
+
+    /// <summary>
+    /// Computes the network prefix address from the IP and prefix length as per CIDR
+    /// </summary>
+    /// <param name="info">The IP info</param>
+    /// <returns>The IP address representing the network prefix</returns>
+    public static IPAddress GetIPNetworkPrefix(this UnicastIPAddressInformation info)
     {
-        return from item in NetworkInterface.GetAllNetworkInterfaces()
-                .Where(n => n.NetworkInterfaceType == type &&
-                            n.OperationalStatus ==
-                            OperationalStatus.Up) // get all operational networks of a given type
-                .Select(n => n.GetIPProperties()) // get the IPs
-            //.Where(n => n.GatewayAddresses.Any())
-            select item.UnicastAddresses.FirstOrDefault(i =>
-                i.Address.AddressFamily == AddressFamily.InterNetwork)
-            into ipInfo
-            where ipInfo != null
-            select IPNetwork.Parse(ipInfo.Address, ipInfo.IPv4Mask);
+        if (info.PrefixLength == 0)
+            return info.Address.AddressFamily == AddressFamily.InterNetwork ? IPAddress.Any : IPAddress.IPv6Any;
+        var maxPrefix = info.Address.AddressFamily == AddressFamily.InterNetwork ? 32 : 128;
+        if (info.PrefixLength == maxPrefix)
+            return info.Address;
+        if (info.PrefixLength > maxPrefix)
+            throw new ArgumentOutOfRangeException("info.PrefixLength");
+
+        var bytes = info.Address.GetAddressBytes();
+        var bitsToBeZeroed = maxPrefix - info.PrefixLength;
+
+        // Big-endian, so we zero bits right to left
+        var i = bytes.Length;
+        while (i --> 0 && bitsToBeZeroed >= 8)
+        {
+            bytes[i] = 0;
+            bitsToBeZeroed -= 8;
+        }
+        if (bitsToBeZeroed > 0)
+        {
+            bytes[i] &= (byte)(byte.MaxValue << bitsToBeZeroed);
+        }
+        return new IPAddress(bytes, info.Address.ScopeId);
     }
+
+    /// <summary>
+    /// Computes the IPNetwork that the IP address belongs to
+    /// </summary>
+    /// <param name="info">The IP info</param>
+    /// <returns>The IPNetwork that th# IP belongs to</returns>
+    public static IPNetwork GetIPNetwork(this UnicastIPAddressInformation info)
+        => new(info.GetIPNetworkPrefix(), info.PrefixLength);
 }

--- a/src/WebApplicationBuilderExtensions.cs
+++ b/src/WebApplicationBuilderExtensions.cs
@@ -1,9 +1,7 @@
-﻿extern alias IPNetwork2;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
-using System.Net.NetworkInformation;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -19,9 +17,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.File.Archive;
 using Serilog.Sinks.SystemConsole.Themes;
-
-using IPNetwork = IPNetwork2::System.Net.IPNetwork2;
-
 
 namespace Nefarius.Utilities.AspNetCore;
 
@@ -121,12 +116,12 @@ public static class WebApplicationBuilderExtensions
                 headerOptions.KnownProxies.Clear();
                 headerOptions.KnownNetworks.Clear();
 
-                foreach (IPNetwork proxy in NetworkUtil.GetNetworks(NetworkInterfaceType.Ethernet))
+                foreach (var proxy in NetworkUtil.GetNetworks())
                 {
                     logger.ForContext<WebApplicationBuilderOptions>()
                         .Information("Adding known network {Subnet}", proxy);
                     headerOptions.KnownNetworks.Add(
-                        new Microsoft.AspNetCore.HttpOverrides.IPNetwork(proxy.Network, proxy.Cidr));
+                        new(proxy.BaseAddress, proxy.PrefixLength));
                 }
             }
 


### PR DESCRIPTION
This is honestly a very unnecessary PR but I felt compelled to do something about this library after reading its maintainer's attitude on the bcl naming collision.

I wasn't sure what the puropse was of filtering only for Ethernet interfaces, but I believe GetUnicastAddresses() does the right thing or close enough. 

The conditional substitute for .NET 8 IPNetwork isn't the prettiest, so up to you if you'd like to keep it or not.